### PR TITLE
Fixing hard-coded storage account name

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "aci-rg" {
 }
 
 resource "azurerm_storage_account" "aci-sa" {
-  name                = "acivststorageacctount"
+  name                = "${var.storage-account-name}"
   resource_group_name = "${azurerm_resource_group.aci-rg.name}"
   location            = "${azurerm_resource_group.aci-rg.location}"
   account_tier        = "Standard"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,3 +13,6 @@ variable "vsts-agent" {
 variable "vsts-pool" {
   default = "ACI-Pool"
 }
+
+variable "storage-account-name" {
+}


### PR DESCRIPTION
Storage Account name of this exemple is hardcoded to "acivststorageacctount" which will cause deployment errors.

This PR provides a new variable called "storage-account-name" so the user can provide a new name and the deployment will work if it is unique.

BTW, I tried to find a way to fix the tutorial at https://open.microsoft.com/2018/05/22/how-to-create-vsts-agent-azure-aci-terraform/ but I couldn't, so step ACI- Provisioning -> Step 2 should now read:

```
terraform apply -var vsts-account= -var vsts-token= -var storage-account-name=
```


Also, I would improve the above command line to something a little bit more clear like:

```
terraform apply -var vsts-account=<vsts_acct_name>  -var vsts-token=<pat> -var storage-account-name=<unique_storage_acct_name>
```

